### PR TITLE
Added option to disable resumable upload and save browser memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ unpause.addEventListener('click', () => {
   url: null, // required - GCS resumable URL
   file: null, // required - instance of File
   chunkSize: 262144, // optional - chunk size must be a multiple of 262144
+  resumable: true, // optional - if true, calculates the checksum of every chunk which allows to resume upload after refreshing tab. May lead to browser crash with bigger files.
   storage: window.localStorage, // optional - storage mechanism used to persist chunk meta data
   contentType: 'text/plain', // optional - content type of the file being uploaded
   onChunkUpload: () => {} // optional - a function that will be called with progress information

--- a/dist/Upload.js
+++ b/dist/Upload.js
@@ -389,7 +389,7 @@ function checkResponseStatus(res, opts) {
       throw new _errors.FileAlreadyUploadedError(opts.id, opts.url);
 
     case 400:
-      throw new InvalidContentRangeError(status);
+      throw new _errors.BadRequestError(status);
 
     case 404:
       throw new _errors.UrlNotFoundError(opts.url);

--- a/dist/UploadStream.js
+++ b/dist/UploadStream.js
@@ -334,7 +334,7 @@ function checkResponseStatus(res, opts) {
       throw new _errors.FileAlreadyUploadedError(opts.id, opts.url);
 
     case 400:
-      throw new InvalidContentRangeError(opts.url);
+      throw new _errors.BadRequestError(res);
 
     case 404:
       throw new _errors.UrlNotFoundError(opts.url);

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -716,7 +716,7 @@ function checkResponseStatus(res, opts) {
       throw new _errors.FileAlreadyUploadedError(opts.id, opts.url);
 
     case 400:
-      throw new InvalidContentRangeError(status);
+      throw new _errors.BadRequestError(status);
 
     case 404:
       throw new _errors.UrlNotFoundError(opts.url);

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -1068,7 +1068,7 @@ function checkResponseStatus(res, opts) {
       throw new _errors.FileAlreadyUploadedError(opts.id, opts.url);
 
     case 400:
-      throw new InvalidContentRangeError(opts.url);
+      throw new _errors.BadRequestError(res);
 
     case 404:
       throw new _errors.UrlNotFoundError(opts.url);
@@ -1103,7 +1103,7 @@ exports.default = (0, _debug2.default)('gcs-browser-upload');
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.UploadAlreadyFinishedError = exports.InvalidChunkSizeError = exports.UploadIncompleteError = exports.MissingOptionsError = exports.UnknownResponseError = exports.UploadUnableToRecoverError = exports.UploadFailedError = exports.UrlNotFoundError = exports.FileAlreadyUploadedError = exports.ResumeIndexesOutOfSyncError = exports.InvalidContentRangeError = exports.DifferentChunkError = undefined;
+exports.UploadAlreadyFinishedError = exports.InvalidChunkSizeError = exports.UploadIncompleteError = exports.MissingOptionsError = exports.UnknownResponseError = exports.BadRequestError = exports.UploadUnableToRecoverError = exports.UploadFailedError = exports.UrlNotFoundError = exports.FileAlreadyUploadedError = exports.ResumeIndexesOutOfSyncError = exports.InvalidContentRangeError = exports.DifferentChunkError = undefined;
 
 var _classCallCheck2 = _dereq_('babel-runtime/helpers/classCallCheck');
 
@@ -1145,7 +1145,7 @@ var InvalidContentRangeError = exports.InvalidContentRangeError = function (_Ext
 
   function InvalidContentRangeError(localResumeIndex, remoteResumeIndex) {
     (0, _classCallCheck3.default)(this, InvalidContentRangeError);
-    return (0, _possibleConstructorReturn3.default)(this, (InvalidContentRangeError.__proto__ || Object.getPrototypeOf(InvalidContentRangeError)).call(this, 'Local resume index (' + localResumeIndex + ') is our of sync with the remote resume inxed (' + remoteResumeIndex + ')'));
+    return (0, _possibleConstructorReturn3.default)(this, (InvalidContentRangeError.__proto__ || Object.getPrototypeOf(InvalidContentRangeError)).call(this, 'Local resume index (' + localResumeIndex + ') is our of sync with the remote resume index (' + remoteResumeIndex + ')'));
   }
 
   return InvalidContentRangeError;
@@ -1206,35 +1206,49 @@ var UploadUnableToRecoverError = exports.UploadUnableToRecoverError = function (
   return UploadUnableToRecoverError;
 }(_es6Error2.default);
 
-var UnknownResponseError = exports.UnknownResponseError = function (_ExtendableError8) {
-  (0, _inherits3.default)(UnknownResponseError, _ExtendableError8);
+var BadRequestError = exports.BadRequestError = function (_ExtendableError8) {
+  (0, _inherits3.default)(BadRequestError, _ExtendableError8);
+
+  function BadRequestError(res) {
+    (0, _classCallCheck3.default)(this, BadRequestError);
+
+    var _this8 = (0, _possibleConstructorReturn3.default)(this, (BadRequestError.__proto__ || Object.getPrototypeOf(BadRequestError)).call(this, 'Bad request'));
+
+    _this8.res = res;
+    return _this8;
+  }
+
+  return BadRequestError;
+}(_es6Error2.default);
+
+var UnknownResponseError = exports.UnknownResponseError = function (_ExtendableError9) {
+  (0, _inherits3.default)(UnknownResponseError, _ExtendableError9);
 
   function UnknownResponseError(res) {
     (0, _classCallCheck3.default)(this, UnknownResponseError);
 
-    var _this8 = (0, _possibleConstructorReturn3.default)(this, (UnknownResponseError.__proto__ || Object.getPrototypeOf(UnknownResponseError)).call(this, 'Unknown response received from GCS'));
+    var _this9 = (0, _possibleConstructorReturn3.default)(this, (UnknownResponseError.__proto__ || Object.getPrototypeOf(UnknownResponseError)).call(this, 'Unknown response received from GCS'));
 
-    console.log('Unknown response res: ', res);
-    _this8.res = res;
-    return _this8;
+    _this9.res = res;
+    return _this9;
   }
 
   return UnknownResponseError;
 }(_es6Error2.default);
 
-var MissingOptionsError = exports.MissingOptionsError = function (_ExtendableError9) {
-  (0, _inherits3.default)(MissingOptionsError, _ExtendableError9);
+var MissingOptionsError = exports.MissingOptionsError = function (_ExtendableError10) {
+  (0, _inherits3.default)(MissingOptionsError, _ExtendableError10);
 
-  function MissingOptionsError(details) {
+  function MissingOptionsError(description) {
     (0, _classCallCheck3.default)(this, MissingOptionsError);
-    return (0, _possibleConstructorReturn3.default)(this, (MissingOptionsError.__proto__ || Object.getPrototypeOf(MissingOptionsError)).call(this, 'Missing required options for Upload - ' + details));
+    return (0, _possibleConstructorReturn3.default)(this, (MissingOptionsError.__proto__ || Object.getPrototypeOf(MissingOptionsError)).call(this, 'Missing required options for Upload - ' + description));
   }
 
   return MissingOptionsError;
 }(_es6Error2.default);
 
-var UploadIncompleteError = exports.UploadIncompleteError = function (_ExtendableError10) {
-  (0, _inherits3.default)(UploadIncompleteError, _ExtendableError10);
+var UploadIncompleteError = exports.UploadIncompleteError = function (_ExtendableError11) {
+  (0, _inherits3.default)(UploadIncompleteError, _ExtendableError11);
 
   function UploadIncompleteError() {
     (0, _classCallCheck3.default)(this, UploadIncompleteError);
@@ -1244,8 +1258,8 @@ var UploadIncompleteError = exports.UploadIncompleteError = function (_Extendabl
   return UploadIncompleteError;
 }(_es6Error2.default);
 
-var InvalidChunkSizeError = exports.InvalidChunkSizeError = function (_ExtendableError11) {
-  (0, _inherits3.default)(InvalidChunkSizeError, _ExtendableError11);
+var InvalidChunkSizeError = exports.InvalidChunkSizeError = function (_ExtendableError12) {
+  (0, _inherits3.default)(InvalidChunkSizeError, _ExtendableError12);
 
   function InvalidChunkSizeError(chunkSize) {
     (0, _classCallCheck3.default)(this, InvalidChunkSizeError);
@@ -1255,8 +1269,8 @@ var InvalidChunkSizeError = exports.InvalidChunkSizeError = function (_Extendabl
   return InvalidChunkSizeError;
 }(_es6Error2.default);
 
-var UploadAlreadyFinishedError = exports.UploadAlreadyFinishedError = function (_ExtendableError12) {
-  (0, _inherits3.default)(UploadAlreadyFinishedError, _ExtendableError12);
+var UploadAlreadyFinishedError = exports.UploadAlreadyFinishedError = function (_ExtendableError13) {
+  (0, _inherits3.default)(UploadAlreadyFinishedError, _ExtendableError13);
 
   function UploadAlreadyFinishedError() {
     (0, _classCallCheck3.default)(this, UploadAlreadyFinishedError);

--- a/dist/errors.js
+++ b/dist/errors.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.UploadAlreadyFinishedError = exports.InvalidChunkSizeError = exports.UploadIncompleteError = exports.MissingOptionsError = exports.UnknownResponseError = exports.UploadUnableToRecoverError = exports.UploadFailedError = exports.UrlNotFoundError = exports.FileAlreadyUploadedError = exports.ResumeIndexesOutOfSyncError = exports.InvalidContentRangeError = exports.DifferentChunkError = undefined;
+exports.UploadAlreadyFinishedError = exports.InvalidChunkSizeError = exports.UploadIncompleteError = exports.MissingOptionsError = exports.UnknownResponseError = exports.BadRequestError = exports.UploadUnableToRecoverError = exports.UploadFailedError = exports.UrlNotFoundError = exports.FileAlreadyUploadedError = exports.ResumeIndexesOutOfSyncError = exports.InvalidContentRangeError = exports.DifferentChunkError = undefined;
 
 var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
 
@@ -45,7 +45,7 @@ var InvalidContentRangeError = exports.InvalidContentRangeError = function (_Ext
 
   function InvalidContentRangeError(localResumeIndex, remoteResumeIndex) {
     (0, _classCallCheck3.default)(this, InvalidContentRangeError);
-    return (0, _possibleConstructorReturn3.default)(this, (InvalidContentRangeError.__proto__ || Object.getPrototypeOf(InvalidContentRangeError)).call(this, 'Local resume index (' + localResumeIndex + ') is our of sync with the remote resume inxed (' + remoteResumeIndex + ')'));
+    return (0, _possibleConstructorReturn3.default)(this, (InvalidContentRangeError.__proto__ || Object.getPrototypeOf(InvalidContentRangeError)).call(this, 'Local resume index (' + localResumeIndex + ') is our of sync with the remote resume index (' + remoteResumeIndex + ')'));
   }
 
   return InvalidContentRangeError;
@@ -106,35 +106,49 @@ var UploadUnableToRecoverError = exports.UploadUnableToRecoverError = function (
   return UploadUnableToRecoverError;
 }(_es6Error2.default);
 
-var UnknownResponseError = exports.UnknownResponseError = function (_ExtendableError8) {
-  (0, _inherits3.default)(UnknownResponseError, _ExtendableError8);
+var BadRequestError = exports.BadRequestError = function (_ExtendableError8) {
+  (0, _inherits3.default)(BadRequestError, _ExtendableError8);
+
+  function BadRequestError(res) {
+    (0, _classCallCheck3.default)(this, BadRequestError);
+
+    var _this8 = (0, _possibleConstructorReturn3.default)(this, (BadRequestError.__proto__ || Object.getPrototypeOf(BadRequestError)).call(this, 'Bad request'));
+
+    _this8.res = res;
+    return _this8;
+  }
+
+  return BadRequestError;
+}(_es6Error2.default);
+
+var UnknownResponseError = exports.UnknownResponseError = function (_ExtendableError9) {
+  (0, _inherits3.default)(UnknownResponseError, _ExtendableError9);
 
   function UnknownResponseError(res) {
     (0, _classCallCheck3.default)(this, UnknownResponseError);
 
-    var _this8 = (0, _possibleConstructorReturn3.default)(this, (UnknownResponseError.__proto__ || Object.getPrototypeOf(UnknownResponseError)).call(this, 'Unknown response received from GCS'));
+    var _this9 = (0, _possibleConstructorReturn3.default)(this, (UnknownResponseError.__proto__ || Object.getPrototypeOf(UnknownResponseError)).call(this, 'Unknown response received from GCS'));
 
-    console.log('Unknown response res: ', res);
-    _this8.res = res;
-    return _this8;
+    _this9.res = res;
+    return _this9;
   }
 
   return UnknownResponseError;
 }(_es6Error2.default);
 
-var MissingOptionsError = exports.MissingOptionsError = function (_ExtendableError9) {
-  (0, _inherits3.default)(MissingOptionsError, _ExtendableError9);
+var MissingOptionsError = exports.MissingOptionsError = function (_ExtendableError10) {
+  (0, _inherits3.default)(MissingOptionsError, _ExtendableError10);
 
-  function MissingOptionsError(details) {
+  function MissingOptionsError(description) {
     (0, _classCallCheck3.default)(this, MissingOptionsError);
-    return (0, _possibleConstructorReturn3.default)(this, (MissingOptionsError.__proto__ || Object.getPrototypeOf(MissingOptionsError)).call(this, 'Missing required options for Upload - ' + details));
+    return (0, _possibleConstructorReturn3.default)(this, (MissingOptionsError.__proto__ || Object.getPrototypeOf(MissingOptionsError)).call(this, 'Missing required options for Upload - ' + description));
   }
 
   return MissingOptionsError;
 }(_es6Error2.default);
 
-var UploadIncompleteError = exports.UploadIncompleteError = function (_ExtendableError10) {
-  (0, _inherits3.default)(UploadIncompleteError, _ExtendableError10);
+var UploadIncompleteError = exports.UploadIncompleteError = function (_ExtendableError11) {
+  (0, _inherits3.default)(UploadIncompleteError, _ExtendableError11);
 
   function UploadIncompleteError() {
     (0, _classCallCheck3.default)(this, UploadIncompleteError);
@@ -144,8 +158,8 @@ var UploadIncompleteError = exports.UploadIncompleteError = function (_Extendabl
   return UploadIncompleteError;
 }(_es6Error2.default);
 
-var InvalidChunkSizeError = exports.InvalidChunkSizeError = function (_ExtendableError11) {
-  (0, _inherits3.default)(InvalidChunkSizeError, _ExtendableError11);
+var InvalidChunkSizeError = exports.InvalidChunkSizeError = function (_ExtendableError12) {
+  (0, _inherits3.default)(InvalidChunkSizeError, _ExtendableError12);
 
   function InvalidChunkSizeError(chunkSize) {
     (0, _classCallCheck3.default)(this, InvalidChunkSizeError);
@@ -155,8 +169,8 @@ var InvalidChunkSizeError = exports.InvalidChunkSizeError = function (_Extendabl
   return InvalidChunkSizeError;
 }(_es6Error2.default);
 
-var UploadAlreadyFinishedError = exports.UploadAlreadyFinishedError = function (_ExtendableError12) {
-  (0, _inherits3.default)(UploadAlreadyFinishedError, _ExtendableError12);
+var UploadAlreadyFinishedError = exports.UploadAlreadyFinishedError = function (_ExtendableError13) {
+  (0, _inherits3.default)(UploadAlreadyFinishedError, _ExtendableError13);
 
   function UploadAlreadyFinishedError() {
     (0, _classCallCheck3.default)(this, UploadAlreadyFinishedError);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gcs-browser-upload-stream",
-  "version": "2.1.31-beta",
+  "version": "2.1.31-beta-helix",
   "description": "Resumable, chunked uploads to Google Cloud Storage from the browser",
   "main": "dist/index.js",
   "scripts": {

--- a/src/Upload.js
+++ b/src/Upload.js
@@ -24,13 +24,14 @@ export default class Upload {
   constructor (args, allowSmallChunks) {
     var opts = {
       chunkSize: MIN_CHUNK_SIZE,
-      storage: args.storage,
       contentType: 'text/plain',
+      file: null,
+      id: null,
       onChunkUpload: () => {},
       onProgress: () => {},
-      id: null,
+      resumable: true,
+      storage: args.storage,
       url: null,
-      file: null,
       ...args
     }
 
@@ -50,7 +51,7 @@ export default class Upload {
 
     this.opts = opts
     this.meta = new FileMeta(opts.id, opts.file.size, opts.chunkSize, opts.storage)
-    this.processor = new FileProcessor(opts.file, opts.chunkSize)
+    this.processor = new FileProcessor(opts.file, opts.chunkSize, opts.resumable)
   }
 
   static safePut = safePut
@@ -84,9 +85,10 @@ export default class Upload {
     }
 
     const uploadChunk = async (checksum, index, chunk) => {
+      const chunkSize = chunk.byteLength || chunk.size;
       const total = opts.file.size
       const start = index * opts.chunkSize
-      const end = index * opts.chunkSize + chunk.byteLength - 1
+      const end = index * opts.chunkSize + chunkSize - 1
 
       const headers = {
         'Content-Type': opts.contentType,
@@ -94,7 +96,7 @@ export default class Upload {
       }
 
       debug(`Uploading chunk ${index}:`)
-      debug(` - Chunk length: ${chunk.byteLength}`)
+      debug(` - Chunk length: ${chunkSize}`)
       debug(` - Start: ${start}`)
       debug(` - End: ${end}`)
 
@@ -108,7 +110,7 @@ export default class Upload {
             totalBytes: total,
             uploadedBytes: start + progressEvent.loaded,
             chunkIndex: index,
-            chunkLength: chunk.byteLength || chunk.size
+            chunkLength: chunkSize,
           })
         }
       })
@@ -121,7 +123,7 @@ export default class Upload {
         totalBytes: total,
         uploadedBytes: end + 1,
         chunkIndex: index,
-        chunkLength: chunk.byteLength || chunk.size,
+        chunkLength: chunkSize,
         isLastChunk: total === end + 1
       })
     }

--- a/src/Upload.js
+++ b/src/Upload.js
@@ -11,7 +11,8 @@ import {
   MissingOptionsError,
   UploadIncompleteError,
   InvalidChunkSizeError,
-  UploadAlreadyFinishedError
+  UploadAlreadyFinishedError,
+  BadRequestError
 } from './errors'
 import * as errors from './errors'
 
@@ -202,7 +203,7 @@ function checkResponseStatus (res, opts, allowed = []) {
       throw new FileAlreadyUploadedError(opts.id, opts.url)
 
     case 400:
-      throw new InvalidContentRangeError(status)
+      throw new BadRequestError(status)
 
     case 404:
       throw new UrlNotFoundError(opts.url)

--- a/src/UploadStream.js
+++ b/src/UploadStream.js
@@ -12,7 +12,8 @@ import {
   UnknownResponseError,
   MissingOptionsError,
   UploadIncompleteError,
-  InvalidChunkSizeError
+  InvalidChunkSizeError,
+  BadRequestError
 } from './errors'
 import * as errors from './errors'
 
@@ -189,7 +190,7 @@ function checkResponseStatus (res, opts, allowed = []) {
       throw new FileAlreadyUploadedError(opts.id, opts.url)
 
     case 400:
-      throw new InvalidContentRangeError(opts.url)
+      throw new BadRequestError(res)
 
     case 404:
       throw new UrlNotFoundError(opts.url)

--- a/src/errors.js
+++ b/src/errors.js
@@ -11,7 +11,7 @@ export class DifferentChunkError extends ExtendableError {
 
 export class InvalidContentRangeError extends ExtendableError {
   constructor (localResumeIndex, remoteResumeIndex) {
-    super(`Local resume index (${localResumeIndex}) is our of sync with the remote resume inxed (${remoteResumeIndex})`)
+    super(`Local resume index (${localResumeIndex}) is our of sync with the remote resume index (${remoteResumeIndex})`)
   }
 }
 
@@ -45,17 +45,23 @@ export class UploadUnableToRecoverError extends ExtendableError {
   }
 }
 
+export class BadRequestError extends ExtendableError {
+  constructor (res) {
+    super('Bad request')
+    this.res = res
+  }
+}
+
 export class UnknownResponseError extends ExtendableError {
   constructor (res) {
     super('Unknown response received from GCS')
-    console.log('Unknown response res: ', res)
     this.res = res
   }
 }
 
 export class MissingOptionsError extends ExtendableError {
-  constructor (details) {
-    super(`Missing required options for Upload - ${details}`)
+  constructor (description) {
+    super(`Missing required options for Upload - ${description}`)
   }
 }
 


### PR DESCRIPTION
There are 3 commits from **joshontheweb** - you can ignore them because they are from the repo that we are already using in Folio Web - I used it to create this fix.